### PR TITLE
Remove dependency on node-fibers (Apple M1 compatibility)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,8 @@
-import { promisify } from 'util';
 import stripOuter from 'strip-outer';
 import camelcaseKeys from 'camelcase-keys';
 import postcss from 'postcss';
 import postcssScss from 'postcss-scss';
 import sass from 'sass';
-import Fiber from 'fibers';
 import jsonFns from 'node-sass-json-functions';
 import fromEntries from '@ungap/from-entries';
 
@@ -51,8 +49,7 @@ export default async (inputCssString, options = {}) => {
 
 	const { functions, ...otherSassOptions } = sassOptions;
 
-	response = await promisify(sass.render)({
-		fiber: Fiber,
+	response = sass.renderSync({
 		data: root.toString(),
 		functions: { ...jsonFns, ...functions },
 		...otherSassOptions

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   "dependencies": {
     "@ungap/from-entries": "^0.2.1",
     "camelcase-keys": "^6.2.2",
-    "fibers": "^5.0.0",
     "node-sass-json-functions": "^3.1.0",
     "postcss": "^8.2.4",
     "postcss-scss": "^3.0.4",


### PR DESCRIPTION
From https://github.com/laverdet/node-fibers:

> **NOTE OF OBSOLESCENCE** -- The author of this project recommends you avoid its use if possible. The
original version of this module targeted nodejs v0.1.x in early 2011 when JavaScript on the server
looked a lot different. Since then [async/await](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function), [Promises](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise), and [Generators](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Generator) were standardized and the ecosystem as a whole has moved in that direction.
>
> I'll continue to support newer versions of nodejs as long as possible but v8 and nodejs are
extraordinarily complex and dynamic platforms. It is inevitable that one day this library will
abruptly stop working and no one will be able to do anything about it.
>
> I'd like to say thank you to all the users of fibers, your support over the years has meant a lot to
me.
>
> **Update** *[April 13th, 2021]* -- Fibers is not compatible with nodejs v16.0.0 or later. Unfortunately, v8
commit [dacc2fee0f](https://github.com/v8/v8/commit/dacc2fee0f815823782a7e432c79c2a7767a4765) is a breaking
change and workarounds are non-trivial.


My guess for why this was used was because of the comment in https://sass-lang.com/documentation/js-api#render:

> When using Dart Sass, renderSync() is almost twice as fast as render() by default, due to the overhead of making the entire evaluation process asynchronous. To avoid this performance hit, you can pass the fiber option to render().

Since the module is already an `async` function, it can just use `sass.renderSync`, it doesn't need to make it a promise and then await it.