### PR TITLE
Fix Non-Functioning Type Declarations

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,14 +17,14 @@ import replaceAll from 'string-replace-all-ponyfill';
 
 /**
  * @typedef {object} Options
- * @property {boolean=}               camelize    Camelize first-level JSON object keys and strip inital `$` (e.g. `$foo-bar` will become `fooBar`).
- * @property {sass.Options<"async">=} sassOptions Options for Sass renderer.
+ * @property {boolean=}                         camelize    Camelize first-level JSON object keys and strip inital `$` (e.g. `$foo-bar` will become `fooBar`).
+ * @property {import("sass").Options<"async">=} sassOptions Options for Sass renderer.
  */
 
 /**
  * @typedef {object} SyncOptions
- * @property {boolean=}              camelize    Camelize first-level JSON object keys and strip inital `$` (e.g. `$foo-bar` will become `fooBar`).
- * @property {sass.Options<"sync">=} sassOptions Options for Sass renderer.
+ * @property {boolean=}                        camelize    Camelize first-level JSON object keys and strip inital `$` (e.g. `$foo-bar` will become `fooBar`).
+ * @property {import("sass").Options<"sync">=} sassOptions Options for Sass renderer.
  */
 
 const sassVariableSelector = '.__sassVars__';
@@ -72,7 +72,7 @@ function sanitizeValue(value) {
 async function main(input, options) {
 	const {
 		camelize = false,
-		sassOptions = /** @type {sass.Options<"async">} */ ({})
+		sassOptions = /** @type {import("sass").Options<"async">} */ ({})
 	} = options || {};
 
 	const cssProcessor = postcss([noop()]);
@@ -148,7 +148,7 @@ async function main(input, options) {
 function mainSync(input, options) {
 	const {
 		camelize = false,
-		sassOptions = /** @type {sass.Options<"sync">} */ ({})
+		sassOptions = /** @type {import("sass").Options<"sync">} */ ({})
 	} = options || {};
 
 	const cssProcessor = postcss([noop()]);

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "postpublish": "GITHUB_TOKEN=$GITHUB_RELEASE_TOKEN github-release-from-changelog",
     "prerelease": "npm run lint && npm run lint:types && npm run build && npm run module-check",
     "release": "np --no-release-draft",
-    "test": "nyc mocha --require esm 'test/**/*.js' && nyc check-coverage",
+    "test": "nyc mocha --require esm 'test/**/*.js' && tsc --noEmit ./cjs/index.d.ts ./esm/index.d.ts && nyc check-coverage",
     "test:watch": "nodemon --exec npm test",
     "version": "if [ $(git rev-parse --abbrev-ref HEAD) == 'master' ]; then sed -i '' '/\\[unreleased\\]:/d' CHANGELOG.md && version-changelog CHANGELOG.md && changelog-verify CHANGELOG.md && git add CHANGELOG.md; else echo; fi"
   },


### PR DESCRIPTION
The current TypeScript declarations included in this module don't seem to work.
TypeScript does not generate type imports for the `sass` object despite the fact that the `sass` object is used for specifying types in several spots in the code as seen here:

https://github.com/niksy/get-sass-vars/blob/f2a813c3e03b23150ecb8c5c1c60fe9d61cb0658/index.js#L21
https://github.com/niksy/get-sass-vars/blob/f2a813c3e03b23150ecb8c5c1c60fe9d61cb0658/index.js#L27

(and more)

To address this issue, changes made in this PR change all type declarations relying on the `sass` object to type declarations with inline `import` statements (i.e. `import("sass").Options` instead of `sass.Options`).

Furthermore, a command has been added to the `test` script (a `tsc` command which only performs type-checking) to reproduce the error - and also for ensuring the integrity to future changes of the type declarations.